### PR TITLE
Add the scripting language Passerine to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ See also [Are we game yet?](http://arewegameyet.com)
 * [gluon-lang/gluon](https://github.com/gluon-lang/gluon) —  A small, statically-typed, functional programming language
 * [murarth/ketos](https://github.com/murarth/ketos) — A Lisp dialect functional programming language serving as a scripting and extension language for rust
 * [moss](https://crates.io/crates/moss) — A dynamically typed scripting language
+* [Passerine](https://github.com/vrtbl/passerine) — A small extensible functional scripting language designed for concise expression with little code [![build](https://github.com/vrtbl/passerine/workflows/Rust/badge.svg)](https://github.com/vrtbl/passerine/actions)
 * [jonathandturner/rhai](https://github.com/jonathandturner/rhai) — A tiny and fast embedded scripting language resembling a combination of JS and Rust
 
 ### Template engine


### PR DESCRIPTION
Hey, I'm the Developer of Passerine, a neat little functional scripting language written in Rust. We just released version 0.9.0 today, and were hoping to add Passerine to the Scripting section of the README. You can learn more about Passerine at the website (https://www.passerine.io/) or look at the GitHub Repo: (https://github.com/vrtbl/passerine). Thanks!