### PR TITLE
Add the Helix editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
     * [lsp-rust](https://github.com/emacs-lsp-legacy/lsp-rust) — Add rls support to [lsp-mode](https://github.com/emacs-lsp/lsp-mode)
   * [gitpod.io](https://gitpod.io) — Online IDE with full Rust support based on Rust Language Server
   * [gnome-builder](https://wiki.gnome.org/Apps/Builder) native support for rust and cargo since Version 3.22.2
+  * [Helix](https://helix-editor.com/) - A post-modern text editor
   * [Kakoune](http://kakoune.org/)
     * [ul/kak-lsp](https://github.com/ul/kak-lsp/) — [LSP](https://microsoft.github.io/language-server-protocol/) client. Implemented in Rust and supports rls out of the box.
   * [NetBeans](https://netbeans.org/)


### PR DESCRIPTION
This adds the Helix editor, an editor and IDE written in Rust, for Rust - and many other languages.

There's much that can be said about it, so for some additional info about the editor, I'd like to refer to the following links:
- https://github.com/contradictioned/areweideyet/issues/106
- [Official website](https://helix-editor.com/)
- [Repository](https://github.com/helix-editor/helix)