### PR TITLE
Add Tuckr to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [yaa110/rubigo](https://github.com/yaa110/rubigo) — Golang dependency tool and package manager, written in Rust [<img src="https://api.travis-ci.org/yaa110/rubigo.svg?branch=master">](https://travis-ci.org/yaa110/rubigo)
 * [whitfin/s3-concat](https://github.com/whitfin/s3-concat) — A command line tool to concatenate Amazon S3 files remotely using flexible patterns.
 * [whitfin/s3-meta](https://github.com/whitfin/s3-meta) — A command line tool to gather metadata about your Amazon S3 buckets.
+* [Tuckr](https://github.com/RaphGL/Tuckr) — A dotfile and symlink manager that requires no configuration, inspired by GNU Stow's approach.
 * [amar-laksh/workstation](https://github.com/amar-laksh/workstation) — A commandline tool to help you manage your workstation by distancing you from your screen, locking your screen when you aren't there among other things with OPENCV!
 * [aleshaleksey/AZDice](https://github.com/aleshaleksey/AZDice) — A dice roll success distribution generator for tabletop homebrewers. [<img src="https://api.travis-ci.org/aleshaleksey/AZDice.svg?branch=master">](https://travis-ci.org/aleshaleksey/AZDice)
 * [fcsonline/tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) — A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator.


### PR DESCRIPTION
Tuckr is a utility I wrote and use to manage my own dotfiles, it follows the GNU Stow approach for managing symlinks but adds extra functionality such as running hooks, symlink integrity checks, encryption, conditional deployment (windows, unix, etc only dotfiles).

To learn more there's the [readme](https://github.com/raphgl/tuckr) for a quick overview and the [wiki](https://github.com/RaphGL/Tuckr/wiki) for a more in depth look