### PR TITLE
Replace Actix with Ractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,7 +1214,7 @@ See also [Are we game yet?](http://arewegameyet.com)
   * [m-labs/smoltcp](https://github.com/m-labs/smoltcp) — A standalone, event-driven TCP/IP stack that is designed for bare-metal, real-time systems [<img src="https://api.travis-ci.org/m-labs/smoltcp.svg?branch=master">](https://travis-ci.org/m-labs/smoltcp)
   * [tokio-rs/tokio](https://github.com/tokio-rs/tokio) — A network application framework for rapid development and highly scalable production deployments of clients and servers.
   * [dylanmckay/protocol](https://github.com/dylanmckay/protocol) — Custom TCP/UDP protocol definitions
-  * [actix/actix](https://github.com/actix/actix) — Actor library for Rust [<img src="https://api.travis-ci.org/actix/actix.svg?branch=master">](https://travis-ci.org/actix/actix)
+  * [slawlor/ractor](https://github.com/slawlor/ractor) - Actor library for Rust
 * NanoMsg
   * [thehydroimpulse/nanomsg.rs](https://github.com/thehydroimpulse/nanomsg.rs) — [nanomsg](https://nanomsg.org/) bindings [<img src="https://api.travis-ci.org/thehydroimpulse/nanomsg.rs.svg?branch=master">](https://travis-ci.org/thehydroimpulse/nanomsg.rs)
 * Nng


### PR DESCRIPTION
Actix is no longer supported/maintained and as per the current archive maintainer (@robjtede) after RustConf'24, they would like people to 

(a) not build on Actix actors anymore and 
(b) if you want actors, use ractor.
