### PR TITLE
add libs.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -1440,6 +1440,7 @@ A registry allows you to publish your Rust libraries as crate packages, to share
 * [Rust Guidelines](http://aturon.github.io/)
 * [RustBooks](https://github.com/sger/RustBooks) — list of RustBooks
 * [Rust Subreddit](https://www.reddit.com/r/rust/) — A subreddit(forum) where rust related questions, articles and resources are posted and discussed
+* [libs.tech/rust](https://libs.tech/rust) - Awesome Rust libraries and hidden gems
 
 ## License
 


### PR DESCRIPTION
Added libs.tech (direct link to Rust category). Libs.tech helps devs stay on top of ecosystems they're interested in.

https://libs.tech/rust