### PR TITLE
Fix "Rust - Production" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Please take a quick gander at the [contribution guidelines](https://github.com/a
 
 ## Applications
 
-See also [Rust — Production](https://www.rust-lang.org/production)(organizations running Rust in production).
+See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organizations running Rust in production) and [Rust Companies](https://github.com/omarabid/rust-companies) (A curated list of companies using Rust in production).
 
 * [alacritty](https://github.com/jwilm/alacritty) — A cross-platform, GPU enhanced terminal emulator
 * [asm-cli-rust](https://github.com/cch123/asm-cli-rust) — interative assembly shell written in rust.


### PR DESCRIPTION
The link https://www.rust-lang.org/production does not exist anymore. I found this link in the previous Rust website: https://prev.rust-lang.org/en-US/friends.html, so I used this instead. Moreover, I found this GitHub repository https://github.com/omarabid/rust-companies that has the same purpose, so I also added this after the first link.