### PR TITLE
Add disruptor crate to concurrency section

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 * [aymanmadkour/glock](https://github.com/aymanmadkour/glock) – Granular locking crate for Rust. [<img src="https://api.travis-ci.org/aymanmadkour/glock.svg?branch=master">](https://travis-ci.org/aymanmadkour/glock)
 * [crossbeam-rs/crossbeam](https://github.com/crossbeam-rs/crossbeam) – Support for parallelism and low-level concurrency in Rust [<img src="https://api.travis-ci.org/crossbeam-rs/crossbeam.svg?branch=master">](https://travis-ci.org/crossbeam-rs/crossbeam)
+* [disruptor](https://crates.io/crates/disruptor) - Low latency thread communication using the Disruptor pattern. Lower latency and higher throughput than Crossbeam but at a higher CPU cost.
 * [orium/archery](https://github.com/orium/archery) [[archery](https://crates.io/crates/archery)] — Library to abstract from `Rc`/`Arc` pointer types. [<img src="https://api.travis-ci.org/orium/archery.svg?branch=master">](https://travis-ci.org/orium/archery)
 * [orx-parallel](https://crates.io/crates/orx-parallel) — High performance, configurable and expressive parallel computation library.
 * [pop-os/bus-writer](https://github.com/pop-os/bus-writer) — Generic single-reader, multi-writer


### PR DESCRIPTION
Added a new entry for the disruptor crate, highlighting its low latency thread communication capabilities. (Disclaimer - I'm the author).