### PR TITLE
Add gitlogue to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ See also [A comparison of operating systems written in Rust](https://github.com/
 * [amar-laksh/workstation](https://github.com/amar-laksh/workstation) — A commandline tool to help you manage your workstation by distancing you from your screen, locking your screen when you aren't there among other things with OPENCV!
 * [aleshaleksey/AZDice](https://github.com/aleshaleksey/AZDice) — A dice roll success distribution generator for tabletop homebrewers. [<img src="https://api.travis-ci.org/aleshaleksey/AZDice.svg?branch=master">](https://travis-ci.org/aleshaleksey/AZDice)
 * [fcsonline/tmux-thumbs](https://github.com/fcsonline/tmux-thumbs) — A lightning fast version of tmux-fingers written in Rust, copy/pasting tmux like vimium/vimperator.
+* [gitlogue](https://github.com/unhappychoice/gitlogue) — A TUI screensaver that visualizes Git commit history in your terminal.
 * [repoch](https://github.com/lucawen/repoch) — Convert epoch to datetime and datetime to epoch [<img src="https://api.travis-ci.com/lucawen/repoch.svg?branch=master">](https://travis-ci.com/lucawen/repoch/)
 * [yaa110/cb](https://github.com/yaa110/cb) — Command line interface to manage clipboard [![Build Status](https://api.travis-ci.org/yaa110/cb.svg?branch=master)](https://travis-ci.org/yaa110/cb)
 * [arjav0703/cargofetch](https://github.com/arjav0703/cargofetch) — A lightweight fetch utility to show metadata about your rust project.


### PR DESCRIPTION
## Summary

Add [gitlogue](https://github.com/unhappychoice/gitlogue) to the Utilities section.

gitlogue is a TUI screensaver that visualizes Git commit history in your terminal. It's built with Rust and ratatui.