### PR TITLE
Add wreq-ruby to FFI / Ruby section

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ See also [Foreign Function Interface](https://doc.rust-lang.org/book/first-editi
 * Ruby
   * [d-unseductable/ruru](https://github.com/d-unseductable/ruru) — native Ruby extensions written in Rust [<img src="https://api.travis-ci.org/d-unseductable/ruru.svg?branch=master">](https://travis-ci.org/d-unseductable/ruru)
   * [danielpclark/rutie](https://github.com/danielpclark/rutie) — native Ruby extensions written in Rust and vice versa [![Build Status](https://api.travis-ci.org/danielpclark/rutie.svg?branch=master)](https://travis-ci.org/danielpclark/rutie)
+  * [SearchApi/wreq-ruby](https://github.com/SearchApi/wreq-ruby) — Ruby HTTP client with browser TLS/HTTP2 fingerprinting, powered by wreq
   * [tildeio/helix](https://github.com/tildeio/helix) — write Ruby classes in Rust [<img src="https://api.travis-ci.org/tildeio/helix.svg?branch=master">](https://travis-ci.org/tildeio/helix)
 * Web Assembly
   * [rustwasm/wasm-pack](https://github.com/rustwasm/wasm-pack) — :package: :sparkles: pack up the wasm and publish it to npm! [<img src="https://api.travis-ci.com/rustwasm/wasm-pack.svg?branch=master">](https://travis-ci.org/rustwasm/wasm-packn)


### PR DESCRIPTION
[wreq-ruby](https://github.com/SearchApi/wreq-ruby) is the first production-ready Ruby HTTP client with real browser TLS/HTTP2 fingerprinting — and it's powered by Rust.

Ruby has never had a library capable of emulating browser TLS and HTTP2 fingerprints. Every existing Ruby HTTP library relies on OpenSSL, which provides no control over TLS extension ordering, cipher suite ordering, or HTTP/2 frame settings. Python, Go, and Node have had solutions for this. Thanks to the wreq crate (403k+ downloads), Ruby now does too.

wreq-ruby wraps the wreq crate via FFI with pre-compiled native gems for Linux and macOS, so Ruby developers don't need a Rust toolchain. It's used in production at [SearchApi](https://www.searchapi.io/) and actively maintained.