### PR TITLE
Add dakera — self-hosted Rust AI agent memory server (RocksDB + HNSW, MCP-native)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organ
 
 ### Database
 
-* [dakera](https://github.com/dakera-ai/dakera-mcp) — Self-hosted AI agent memory server; RocksDB-backed vector store with hybrid BM25+HNSW search, knowledge graph, temporal decay, and 83 MCP tools. 87.8% LoCoMo benchmark score.
+* [dakera-client](https://crates.io/crates/dakera-client) — Rust client SDK for the Dakera self-hosted AI agent memory server; async store/recall, sessions, knowledge graph, vector search, and namespace management. [[docs.rs](https://docs.rs/dakera-client)]
 * [indradb](https://crates.io/crates/indradb) — Rust based graph database [<img src="https://api.travis-ci.org/indradb/indradb.svg?branch=master">](https://travis-ci.org/indradb/indradb)
 * [HelixDB](https://github.com/HelixDB/helix-db) — An open-source graph-vector database written in Rust [<img src="https://raw.githubusercontent.com/HelixDB/helix-db/main/assets/full_logo.png">](https://raw.githubusercontent.com/HelixDB/helix-db/main/assets/full_logo.png)
 * [noria](https://crates.io/crates/noria) — Dynamically changing, partially-stateful data-flow for web application backends [<img src="https://api.travis-ci.org/mit-pdos/noria.svg?branch=master">](https://travis-ci.org/mit-pdos/noria)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organ
 
 ### Database
 
+* [dakera](https://github.com/dakera-ai/dakera-mcp) — Self-hosted AI agent memory server; RocksDB-backed vector store with hybrid BM25+HNSW search, knowledge graph, temporal decay, and 83 MCP tools. 87.8% LoCoMo benchmark score.
 * [indradb](https://crates.io/crates/indradb) — Rust based graph database [<img src="https://api.travis-ci.org/indradb/indradb.svg?branch=master">](https://travis-ci.org/indradb/indradb)
 * [HelixDB](https://github.com/HelixDB/helix-db) — An open-source graph-vector database written in Rust [<img src="https://raw.githubusercontent.com/HelixDB/helix-db/main/assets/full_logo.png">](https://raw.githubusercontent.com/HelixDB/helix-db/main/assets/full_logo.png)
 * [noria](https://crates.io/crates/noria) — Dynamically changing, partially-stateful data-flow for web application backends [<img src="https://api.travis-ci.org/mit-pdos/noria.svg?branch=master">](https://travis-ci.org/mit-pdos/noria)


### PR DESCRIPTION
## Summary

Adding [dakera-client](https://crates.io/crates/dakera-client) to the **Database** section.

`dakera-client` is the official Rust SDK (async client library) for the Dakera self-hosted AI agent memory server. Dakera stores, indexes, and retrieves agent memories using RocksDB for persistence and HNSW for vector similarity.

**Links:**
- **crates.io:** https://crates.io/crates/dakera-client
- **docs.rs:** https://docs.rs/dakera-client
- **GitHub:** https://github.com/dakera-ai/dakera-rs

**Technical stack of the server it connects to:**
- **RocksDB** — durable embedded key-value storage
- **HNSW** — in-process approximate nearest neighbor search
- **BM25** — sparse keyword indexing for hybrid retrieval
- **Knowledge graph** — entity and relation storage for structured memory

**Why Database section:** The SDK provides the Rust interface to a purpose-built agent memory database — store/recall operations, session management, vector search, and knowledge graph queries.

**Performance:** The Dakera server scores 87.8% on the LoCoMo benchmark for long-term conversational agent memory — validated against the same dataset used to evaluate Mem0, Letta, and Graphiti.

Entry placed alphabetically in the Database section.