### PR TITLE
Add Oryxis SSH client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,7 @@ See also [Are we game yet?](http://arewegameyet.com)
 * SSH
   * [alexcrichton/ssh2-rs](https://github.com/alexcrichton/ssh2-rs) — [libssh2](https://www.libssh2.org/) bindings [<img src="https://api.travis-ci.com/alexcrichton/ssh2-rs.svg?branch=master">](https://travis-ci.org/alexcrichton/ssh2-rs)
   * [Thrussh](https://github.com/pijul-scm/thrussh/) — an SSH library written from scratch in Rust, backed by [libsodium](https://download.libsodium.org/doc/)
+  * [Oryxis](https://github.com/wilsonglasser/oryxis) — A modern SSH client built entirely in Rust. [<img src="hhttps://img.shields.io/github/v/release/wilsonglasser/oryxis?color=green">](https://github.com/wilsonglasser/oryxis/releases/latest)
 * Stomp
   * [zslayton/stomp-rs](https://github.com/zslayton/stomp-rs) — A [STOMP 1.2](http://stomp.github.io/stomp-specification-1.2.html) client implementation in Rust [<img src="https://api.travis-ci.org/zslayton/stomp-rs.svg?branch=master">](https://travis-ci.org/zslayton/stomp-rs)
 * uTP


### PR DESCRIPTION
Adds Oryxis to the SSH section.

https://github.com/wilsonglasser/oryxis

A modern SSH client built entirely in Rust. Fast, encrypted, native.  AGPL-3.0 license.