### PR TITLE
Add Darkly and Graphite to graphics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ See also [Games Made With Piston](https://github.com/PistonDevelopers/piston/wik
 
 ### Graphics
 
+* [Darkly](https://github.com/darkly-art/darkly) - Entropic editor for digital artists and painters
+* [Graphite](https://github.com/GraphiteEditor/graphite) - Vector-based graphics editor
 * [Limeth/euclider](https://github.com/Limeth/euclider) — A real-time 4D CPU ray tracer [<img src="https://api.travis-ci.org/Limeth/euclider.svg?branch=master">](https://travis-ci.org/Limeth/euclider)
 * [ivanceras/svgbob](https://github.com/ivanceras/svgbob) — converts ASCII diagrams into SVG graphics [<img src="https://api.travis-ci.org/ivanceras/svgbob.svg">](https://travis-ci.org/ivanceras/svgbob)
 * [RazrFalcon/svgcleaner](https://github.com/RazrFalcon/svgcleaner) — tidies SVG graphics


### PR DESCRIPTION
[Darkly](https://github.com/darkly-art/darkly) is a raster-first photo editor geared toward digital painters, with a node-based brush engine and procreate-like stroke stabilization. (Shameless plug, I built Darkly.)

[Graphite](https://github.com/GraphiteEditor/Graphite) is a vector-first and written in Rust, with a node-based vector engine, great for graphic design and nondestructive workflows.

Both run in the browser, and are written in Rust  + Svelte + Webassembly.