### PR TITLE
add vgnapuga/meon into Libraries/Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,6 +1300,7 @@ See also [Are we game yet?](http://arewegameyet.com)
   * [ptal/oak](https://github.com/ptal/oak) — A typed PEG parser generator (compiler plugin)
   * [rustless/queryst](https://github.com/rustless/queryst) — A query string parsing library for Rust inspired by https://github.com/ljharb/qs [![Build Status](https://api.travis-ci.org/rustless/queryst.svg?branch=master)](https://travis-ci.org/rustless/queryst)
   * [freestrings/jsonpath](https://github.com/freestrings/jsonpath) - [JsonPath](https://goessner.net/articles/JsonPath/) engine written in Rust. Webassembly and Javascript support too [![Build Status](https://api.travis-ci.org/freestrings/jsonpath.svg?branch=master)](https://travis-ci.org/freestrings/jsonpath)
+  * [vgnapuga/meon](https://github.com/vgnapuga/meon) — declarative parsing engine that outputs a flat struct-of-arrays instead of an AST, with standalone per-type parsing methods, O(1) access, and benchmarks included [![Build Status](https://github.com/vgnapuga/meon/actions/workflows/ci.yml/badge.svg)](https://github.com/vgnapuga/meon/actions)
 
 ### Packaging formats
 


### PR DESCRIPTION
Adding meon — a declarative parsing engine that outputs a flat struct-of-arrays instead of a tree/AST (one Vec per element kind), giving O(1) per-type access and cache-friendly iteration. Unlike combinator-based parsers in this section (nom, chomp, combine), grammars are declared once via a macro and compiled into a parser at build time — no runtime dispatch. Includes reference grammars for Markdown and JSON, plus benchmarks and fuzzing.