### PR TITLE
Add nika (AI workflow engine) to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organ
 * [MaidSafe](https://maidsafe.net) — A decentralized platform.
 * [mdBook](https://crates.io/crates/mdbook) — A command line utility to create books from markdown files [<img src="https://api.travis-ci.com/azerupi/mdBook.svg?branch=master">](https://travis-ci.org/azerupi/mdBook)
 * [nicohman/eidolon](https://github.com/nicohman/eidolon) — A steam and drm-free game registry and launcher for linux and macosx [<img src="https://api.travis-ci.org/nicohman/eidolon.svg?branch=master">](https://travis-ci.org/nicohman/eidolon)
+* [nika](https://github.com/supernovae-st/nika) — Intent-as-code workflow engine for AI: reviewable YAML DAGs statically checked (schema, permits, honest cost floor) before any token is spent. Single binary.
 * [notty](https://github.com/withoutboats/notty) — A new kind of terminal
 * [Pijul](https://pijul.org) — A patch-based distributed version control system
 * [rsign](https://crates.io/crates/rsign) — A simple command-line tool used to generate/sign/verify digital signatures designed to be compatible with Minisign  [![Codeship Status for danielrangel/rsign](https://app.codeship.com/projects/60b28d80-7645-0135-4402-1639b58199d0/status?branch=master)](https://app.codeship.com/projects/244452)


### PR DESCRIPTION
Adds **Nika** (alphabetical, house format).

Intent-as-code workflow engine for AI in a single Rust binary (AGPL-3.0): repeated AI work becomes a reviewable `.nika.yaml` DAG — statically checked (schema, permits, honest cost floor) before any token is spent, executed budget-capped with tamper-evident traces. Local-first providers (Ollama, llama.cpp, vLLM) plus cloud; ships a read-only MCP oracle, a VS Code extension and a GitHub Action.

Disclosure: I'm the author.
