### PR TITLE
Add aisk/rust-fire to Command-line argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 ### Command-line
 
 * Argument parsing
+  * [aisk/rust-fire](https://github.com/aisk/rust-fire) [[fire](https://crates.io/crates/fire)] — Turn your function(s) to a command line app with one line of code [<img src="https://github.com/aisk/rust-fire/actions/workflows/ci.yml/badge.svg">](https://github.com/aisk/rust-fire/actions/workflows/ci.yml)
   * [clap-rs](https://github.com/clap-rs/clap) [[clap](https://crates.io/crates/clap)] — A simple to use, full featured command-line argument parser [<img src="https://api.travis-ci.com/clap-rs/clap-rs.svg?branch=master">](https://travis-ci.org/clap-rs/clap-rs)
   * [docopt/docopt.rs](https://github.com/docopt/docopt.rs) [[docopt](https://crates.io/crates/docopt)] — A Rust implementation of [DocOpt](http://docopt.org) [<img src="https://api.travis-ci.org/docopt/docopt.rs.svg?branch=master">](https://travis-ci.org/docopt/docopt.rs)
   * [TeXitoi/structopt](https://github.com/TeXitoi/structopt) [[structopt](https://crates.io/crates/structopt)] — parse command line argument by defining a struct [<img src="https://api.travis-ci.org/TeXitoi/structopt.svg?branch=master">](https://travis-ci.org/TeXitoi/structopt)


### PR DESCRIPTION
Adding my crate [fire](https://crates.io/crates/fire) ([aisk/rust-fire](https://github.com/aisk/rust-fire)) — a proc-macro that turns a function, or an inline module of functions, into a CLI app via a single `#[fire::main]` attribute. Python-fire vibes, but for Rust.

Put it at the top of Argument parsing to keep the alphabetical order.