### PR TITLE
feat: add hyperlane (HTTP Server) and euv (GUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,6 +1163,7 @@ See also [Are we game yet?](http://arewegameyet.com)
 [[gui](https://crates.io/keywords/gui)]
 
 * [autopilot-rs/autopilot-rs](https://github.com/autopilot-rs/autopilot-rs) — A simple, cross-platform GUI automation library for Rust.
+* [euv-dev/euv](https://github.com/euv-dev/euv) — A declarative, cross-platform UI framework for Rust with virtual DOM, reactive signals, and HTML macros for WebAssembly. [![CI](https://github.com/euv-dev/euv/actions/workflows/rust.yml/badge.svg)](https://github.com/euv-dev/euv/actions)
 * [maps4print/azul](https://github.com/maps4print/azul) — A free, functional, IMGUI-oriented GUI framework for rapid development of desktop applications written in Rust, supported by the Mozilla WebRender rendering engine. [<img src="https://api.travis-ci.org/maps4print/azul.svg?branch=master">](https://travis-ci.org/maps4print/azul)
 * [PistonDevelopers/conrod](https://github.com/PistonDevelopers/conrod/) — An easy-to-use, immediate-mode, 2D GUI library written entirely in Rust [<img src="https://api.travis-ci.org/PistonDevelopers/conrod.svg?branch=master">](https://travis-ci.org/PistonDevelopers/conrod)
 * [rise-ui](https://github.com/rise-ui/rise) — Simple component-based cross-Platform GUI Toolkit for developing beautiful and user-friendly interfaces.
@@ -1418,6 +1419,7 @@ See also [Are we web yet?](http://www.arewewebyet.org) and [Rust web framework c
   * [actix/actix-web](https://github.com/actix/actix-web) — A lightweight async web framework for Rust with websocket support [<img src="https://api.travis-ci.org/actix/actix-web.svg?branch=master">](https://travis-ci.org/actix/actix-web)
   * [branca](https://crates.io/crates/branca) — A Pure Rust implementation of Branca for Authenticated and Encrypted API tokens. [<img src="https://api.travis-ci.org/return/branca.svg?branch=master">](https://travis-ci.org/return/branca)
   * [Gotham](https://github.com/gotham-rs/gotham) — A flexible web framework that does not sacrifice safety, security or speed. [<img src="https://api.travis-ci.org/gotham-rs/gotham.svg?branch=master">](https://travis-ci.org/gotham-rs/gotham)
+* [hyperlane-dev/hyperlane](https://github.com/hyperlane-dev/hyperlane) — A lightweight, high-performance, cross-platform Rust HTTP server library built on Tokio with built-in support for middleware, WebSocket, SSE, and raw TCP. [![CI](https://github.com/hyperlane-dev/hyperlane/actions/workflows/rust.yml/badge.svg)](https://github.com/hyperlane-dev/hyperlane/actions)
   * [hyperium/hyper](https://github.com/hyperium/hyper) — an HTTP implementation [<img src="https://api.travis-ci.org/hyperium/hyper.svg?branch=master">](https://travis-ci.org/hyperium/hyper)
   * [GildedHonour/frank_jwt](https://github.com/GildedHonour/frank_jwt) — JSON Web Token implementation in Rust. [<img src="https://api.travis-ci.org/GildedHonour/frank_jwt.svg?branch=master">](https://travis-ci.org/GildedHonour/frank_jwt)
   * [handlebars-rust](https://github.com/sunng87/handlebars-rust) — an Iron web framework middleware. [<img src="https://api.travis-ci.org/sunng87/handlebars-iron.svg?branch=master">](https://travis-ci.org/sunng87/handlebars-iron)


### PR DESCRIPTION
## Summary

Two alphabetical insertions, one for hyperlane in **Libraries → Web programming → HTTP Server**, one for euv in **Libraries → GUI**.

## Diff

```diff
+* [euv-dev/euv](https://github.com/euv-dev/euv) — A declarative, cross-platform UI framework for Rust with virtual DOM, reactive signals, and HTML macros for WebAssembly. [![CI](https://github.com/euv-dev/euv/actions/workflows/rust.yml/badge.svg)](https://github.com/euv-dev/euv/actions)
+* [hyperlane-dev/hyperlane](https://github.com/hyperlane-dev/hyperlane) — A lightweight, high-performance, cross-platform Rust HTTP server library built on Tokio with built-in support for middleware, WebSocket, SSE, and raw TCP. [![CI](https://github.com/hyperlane-dev/hyperlane/actions/workflows/rust.yml/badge.svg)](https://github.com/hyperlane-dev/hyperlane/actions)
```

Total: 1 file, +2 lines, -0 lines.

## Why these two

- **hyperlane** (118★, 326k crates downloads) is a long-active Tokio-based HTTP server with first-class middleware, WebSocket, SSE, and raw TCP support. Sits naturally next to `hyperium/hyper` in the HTTP Server list.
- **euv** (3181 crates downloads) is a WASM-targeted declarative UI framework with virtual DOM and reactive signals — a sister project to `yew`, `seed`, `iced`.

Both repos publish to crates.io and ship a public `.github/workflows/rust.yml` so the badges resolve cleanly.