### PR TITLE
Add Tura to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organ
 * [Sandstorm Collections App](https://github.com/sandstorm-io/collections-app)
 * [Servo](https://github.com/servo/servo) — A prototype web browser engine
 * [trust-dns](https://crates.io/crates/trust-dns) — A DNS-server [<img src="https://api.travis-ci.org/bluejekyll/trust-dns.svg?branch=master">](https://travis-ci.org/bluejekyll/trust-dns)
+* [Tura](https://github.com/Tura-AI/tura) — A local, open-source coding agent with terminal, TUI, and desktop interfaces.
 * [Weld](https://github.com/serayuzgur/weld) — Full fake REST API generator [<img src="https://api.travis-ci.org/serayuzgur/weld.svg">](https://travis-ci.org/serayuzgur/weld)
 * [kytan](https://github.com/changlan/kytan) - High Performance Peer-to-Peer VPN
 * [WezTerm](https://github.com/wez/wezterm) — A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust


### PR DESCRIPTION
## Summary

Adds [Tura](https://github.com/Tura-AI/tura) to **Applications** in alphabetical order.

Tura is a local, open-source coding agent implemented primarily in Rust, with terminal, TUI, and desktop interfaces. The entry follows the repository's one-line format and sits between trust-dns and Weld.

## Checks

- Read and followed CONTRIBUTING.md
- Searched README, open/closed pull requests, and issues for an existing Tura entry
- Verified the rendered README preview
- Verified the target link returns HTTP 200
- Diff is one file with one added line

Disclosure: I am affiliated with Tura and am submitting it on the project's behalf.