### PR TITLE
Add xezim to Rust development and testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,7 @@ See also [Are we (I)DE yet?](https://areweideyet.com/) and [Rust Tools](https://
 * [rust-fuzz/afl.rs](https://github.com/rust-fuzz/afl.rs) — A Rust fuzzer, using [AFL](http://lcamtuf.coredump.cx/afl/) [<img src="https://api.travis-ci.org/rust-fuzz/afl.rs.svg?branch=master">](https://travis-ci.org/rust-fuzz/afl.rs)
 * [tarpaulin](https://crates.io/crates/cargo-tarpaulin) — A code coverage tool designed for Rust [<img src="https://api.travis-ci.org/repositories/xd009642/tarpaulin.svg?branch=master">](https://travis-ci.org/xd009642/tarpaulin)
 * [trust](https://github.com/japaric/trust) — A Travis CI and AppVeyor template to test your Rust crate on 5 architectures and publish binary releases of it for Linux, macOS and Windows
+* [xezim](https://github.com/aionhw/xezim) — An Extensible SystemVerilog simulator and verification engine.
 
 ### Transpiling
 


### PR DESCRIPTION
### Summary
This PR adds **xezim** to the `Development tools > Testing` section.

### Project Overview
- **Name:** xezim
- **Link:** https://github.com/your-username/xezim
- **Description:** Extensible SystemVerilog simulator and HDL verification engine written in Rust.

### Checklist
- [x] Entry added in alphabetical order.
- [x] Description is concise, accurate, and neutral.
- [x] Link points to active repository.
