### PR TITLE
Add gitside

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ See also [Friends of Rust](https://prev.rust-lang.org/en-US/friends.html) (Organ
 * [Factotum](https://github.com/snowplow/factotum) — [A system to programmatically run data pipelines](https://snowplowanalytics.com/blog/2016/04/09/introducing-factotum-data-pipeline-runner/) [<img src="https://api.travis-ci.org/snowplow/factotum.svg?branch=master">](https://travis-ci.org/snowplow/factotum)
 * [fcsonline/drill](https://github.com/fcsonline/drill) — A HTTP load testing application inspired by Ansible syntax [<img src="https://api.travis-ci.org/fcsonline/drill.svg?branch=master">](https://travis-ci.org/fcsonline/drill)
 * [Fractalide](https://github.com/fractalide/fractalide) — Simple Rust Microservices
+* [gitside](https://crates.io/crates/gitside) — A VS Code-inspired source-control panel for the terminal.
 * [habitat](https://www.habitat.sh) — An tool created by [Chef](https://www.chef.io/) to build, deploy, and manage applications.
 * [Herd](https://github.com/imjacobclark/Herd) — an experimental HTTP load testing application
 * [intecture/api](https://github.com/intecture/api) — an API-driven server management and configuration tool [<img src="https://api.travis-ci.org/intecture/api.svg?branch=master">](https://travis-ci.org/intecture/api)


### PR DESCRIPTION
## What changed

Add Gitside to the Applications section.

## Why

Gitside is a Rust-built, cross-platform source-control panel for the terminal. It brings a VS Code-style Git workflow to full-screen terminals, tmux side panes, and other terminal environments.

The entry links to its published crates.io package and follows the repository's alphabetical application-list format.
