### PR TITLE
Add arthiqlabs/vedaksha to Astronomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 [[astronomy](https://crates.io/keywords/astronomy)]
 
+* [arthiqlabs/vedaksha](https://github.com/arthiqlabs/vedaksha) — Clean-room astronomical ephemeris and Vedic computation engine with JPL-validated positions, native Jyotish primitives, WebAssembly and Python bindings, and an MCP server.
 * [saurvs/astro-rust](https://github.com/saurvs/astro-rust) — astronomy for Rust [<img src="https://api.travis-ci.org/saurvs/astro-rust.svg?branch=master">](https://travis-ci.org/saurvs/astro-rust)
 * [fitsio](https://crates.io/crates/fitsio) — fits interface library wrapping cfitsio [<img src="https://api.travis-ci.org/mindriot101/rust-fitsio.svg?branch=master">](https://travis-ci.org/mindriot101/rust-fitsio)
 * [flosse/rust-sun](https://github.com/flosse/rust-sun) — A rust port of the JS library suncalc [<img src="https://api.travis-ci.org/flosse/rust-sun.svg?branch=master">](https://travis-ci.org/flosse/rust-sun)


### PR DESCRIPTION
Adds [arthiqlabs/vedaksha](https://github.com/arthiqlabs/vedaksha) to the Astronomy section.

A clean-room astronomical ephemeris and Vedic astrology engine in Rust. Reads JPL DE440s/DE441 SPK kernels directly, and also ships VSOP87A + ELP/MPP02 compiled to constants so it runs with no data files at all — which is what makes the WebAssembly and edge builds possible.

Positions are validated against JPL Horizons: 0.103″ mean across 15,350 comparisons over 1900–2025, from a 24,350-row committed oracle. Published as seven crates; `vedaksha` is the umbrella.

I dropped the `[[crate](crates.io)]` bracket from my first draft — that style appears nowhere in this README, so the entry matches the Astronomy section's neighbours instead. Placed alphabetically.

Disclosure: I maintain this project.