### PR TITLE
Add fastalp under Compression section

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,8 @@ See also [About Rust’s Machine Learning Community](https://medium.com/@autumn_
 
 ### Compression
 
+* [ALP](https://github.com/webc-site/wedb_embed/tree/main/fastalp)
+  * [fastalp](https://github.com/webc-site/wedb_embed/tree/main/fastalp) [[fastalp](https://crates.io/crates/fastalp)] — Adaptive Lossless Floating-Point (ALP) compression algorithm for f32 and f64
 * [Brotli](https://opensource.googleblog.com/2015/09/introducing-brotli-new-compression.html)
   * [ende76/brotli-rs](https://github.com/ende76/brotli-rs) — implementation of Brotli compression
   * [dropbox/rust-brotli](https://github.com/dropbox/rust-brotli) — Brotli decompressor in Rust that optionally avoids the stdlib


### PR DESCRIPTION
I have added [fastalp](https://github.com/webc-site/fastalp) under the Compression section.

fastalp is a pure Rust implementation of the Adaptive Lossless Floating-Point (ALP) compression algorithm (SIGMOD 2024) for f32 and f64, available on [crates.io](https://crates.io/crates/fastalp).

Technical characteristics and benchmark measurements:
- Decompression throughput: Achieves 23.55 GB/s geometric mean across all 37 benchmarks (peaking between 55 and 77 GB/s) in single-core pure-register SIMD decoding. In end-to-end time series decompression benchmarks (graupel), single-core throughput reaches 254 Mpt/s.
- Compression throughput: 3.55 GB/s geometric mean end-to-end compression throughput (4.4 to 6.8 GB/s in regular blocks, up to 20+ GB/s with parameter caching; 169 Mpt/s in time-series encoder benchmarks).
- Compression ratio: Averages 6.83x geometric mean across all 37 benchmarks (2.29x across the 31 ALP paper benchmark datasets).
- Fallback mechanism: Built-in Raw Fallback ensures zero expansion on high-entropy noise sequences.
- APIs: Zero-heap compress_into and decompress_into interfaces.

![fastalp Floating-Point Compression Performance & Ratio Benchmark](https://fastly.jsdelivr.net/gh/webc-fs/-@53/SLHLoauQAr1wmk3FJZTQ.svg)
